### PR TITLE
Adjust modal border clipping for rounded corners

### DIFF
--- a/mobile/assets/components/BaseModal.jsx
+++ b/mobile/assets/components/BaseModal.jsx
@@ -2,17 +2,20 @@ import React from "react";
 import { View, Text, StyleSheet, Dimensions } from "react-native";
 import Modal from "react-native-modal";
 import { BlurView } from "expo-blur";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 const { height: windowHeight } = Dimensions.get("window");
 
 const BaseModal = ({ visible, onClose, title, children }) => {
+  const insets = useSafeAreaInsets();
+
   return (
     <Modal
       isVisible={visible}
       swipeDirection="down"
       onSwipeComplete={onClose}
       onBackdropPress={onClose}
-      style={styles.modal}
+      style={[styles.modal, { marginBottom: insets.bottom }]}
       backdropOpacity={0.7}
       animationIn="slideInUp"
       animationOut="slideOutDown"
@@ -22,7 +25,7 @@ const BaseModal = ({ visible, onClose, title, children }) => {
         tint="light"
         style={styles.blurContainer}
       >
-        <View style={styles.modalContainer}>
+        <View style={[styles.modalContainer, { paddingBottom: 30 + insets.bottom }]}>
           <View style={styles.header}>
             <Text style={styles.title}>{title}</Text>
           </View>


### PR DESCRIPTION
Adjust BaseModal to prevent border clipping on devices with rounded corners.

The modal now respects safe area insets by applying a bottom margin and increasing internal padding, ensuring the border is fully visible above the device's rounded edges.

---
<a href="https://cursor.com/background-agent?bcId=bc-587a189a-e1d6-46df-9487-4c78810654e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-587a189a-e1d6-46df-9487-4c78810654e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

